### PR TITLE
Bitmap cache should use Dictionary not Object (renamed, was: Clear cache)

### DIFF
--- a/net/flashpunk/FP.as
+++ b/net/flashpunk/FP.as
@@ -651,6 +651,14 @@
 		}
 		
 		/**
+		 * Clears the cache of BitmapData objects used by the getBitmap method.
+		 */
+		public static function clearBitmapCache():void
+		{
+			_bitmap = { };
+		}
+		
+		/**
 		 * Sets a time flag.
 		 * @return	Time elapsed (in milliseconds) since the last time flag was set.
 		 */


### PR DESCRIPTION
This new method should be helpful for people to troubleshoot memory leak issues, as it lets them clear out the cache of BitmapData instances that's maintained by the getBitmap() method.

I'm not sure it's a great thing for games to use in production, but even if it's being misused it probably won't hurt much.
