### PR TITLE
Masklist.collideMasklist always returns true

### DIFF
--- a/net/flashpunk/masks/Masklist.as
+++ b/net/flashpunk/masks/Masklist.as
@@ -38,7 +38,7 @@
 					if (a.collide(b)) return true;
 				}
 			}
-			return true;
+			return false;
 		}
 		
 		/**


### PR DESCRIPTION
Fix it to return `false` if the two `Masklist`s don’t intersect.
