### PR TITLE
Particle gravity

### DIFF
--- a/net/flashpunk/graphics/Emitter.as
+++ b/net/flashpunk/graphics/Emitter.as
@@ -109,14 +109,7 @@
 				// get position
 				td = (type._ease == null) ? t : type._ease(t);
 				_p.x = _point.x + p._x + p._moveX * td;
-				_p.y = _point.y + p._y + p._moveY * td;
-				
-				// stops particles from moving when gravity is enabled
-				// and if emitter.active = false (for game pausing for example)
-				if (active)
-				{
-					p._moveY += p._gravity * td;
-				}
+				_p.y = _point.y + p._y + p._moveY * td + p._gravity * td * td;
 				
 				// get frame
 				rect.x = rect.width * type._frames[uint(td * type._frameCount)];


### PR DESCRIPTION
The current code implementing gravity for particles is not good. First of all, it makes the Emitter class's render() method not idempotent (that means, calling it twice in succession will give get different results) and will give different results depending on the frame rate. Its calculation for the actual position of the particles is non-physical (they'll follow cubic roughly parabolic paths, but not what you'd expect given their initial speed and the gravity setting).

My new code is simpler and more correct. It simply takes the acceleration from gravity into account when calculating the position, rather than changing the particle's velocity from frame to frame. Code using the old gravity logic may need to be changes to the magnitude of the gravity it requests, but at least this code will give allow the use of sensible units (pixels/sec/sec).
