### PR TITLE
Fix for Spritemaps with source image width that is not an exact multiple of its frame width

### DIFF
--- a/net/flashpunk/graphics/Spritemap.as
+++ b/net/flashpunk/graphics/Spritemap.as
@@ -54,9 +54,8 @@
 		override public function updateBuffer(clearBefore:Boolean = false):void 
 		{
 			// get position of the current frame
-			_rect.x = _rect.width * _frame;
-			_rect.y = uint(_rect.x / _width) * _rect.height;
-			_rect.x %= _width;
+			_rect.x = _rect.width * (_frame % _columns);
+			_rect.y = _rect.height * uint(_frame / _columns);
 			if (_flipped) _rect.x = (_width - _rect.width) - _rect.x;
 			
 			// update the buffer


### PR DESCRIPTION
While investigating an issue from a forum post (http://flashpunk.net/forums/index.php?topic=3330.msg22638#msg22638), I discovered that the Spritemap class does not behave correctly if the image it is passed as its source does not have a width that is an exact multiple of the requested frame width.

The issue was due to how the updateBuffer() method was calculating the location within the source image to grab pixels from. I updated it to use the _columns property, rather than the awkward calculation it was doing before using _width. With my change, extra pixels along the right edge of an image will be ignored.

I doubt this will have an compatibility issues, as the behavior of the class will be the same for source image sizes that are multiples of the frame width. Anyone who previously attempted to use an image that was not an exact multiple of the frame width would not have gotten useful results, so this change is unlikely to break any existing code. It simply opens up new options for future projects.
