### PR TITLE
Motion tween update

### DIFF
--- a/net/flashpunk/tweens/motion/Motion.as
+++ b/net/flashpunk/tweens/motion/Motion.as
@@ -10,12 +10,38 @@
 		/**
 		 * Current x position of the Tween.
 		 */
-		public var x:Number = 0;
+		public function get x():Number { return _x; }
+		public function set x(value:Number):void
+		{
+			_x = value;
+			if (_object)
+				_object.x = _x;
+		}
 		
 		/**
 		 * Current y position of the Tween.
 		 */
-		public var y:Number = 0;
+		public function get y():Number { return _y; }
+		public function set y(value:Number):void
+		{
+			_y = value;
+			if (_object)
+				_object.y = _y;
+		}
+		
+		/**
+		 * Target object for the tween. Must have an x and a y property.
+		 */
+		public function get object():Object { return _object; }
+		public function set object(value:Object):void
+		{
+			_object = value;
+			if (_object)
+			{
+				_object.x = _x;
+				_object.y = _y;
+			}
+		}
 		
 		/**
 		 * Constructor.
@@ -28,5 +54,9 @@
 		{
 			super(duration, type, complete, ease);
 		}
+		
+		protected var _x:Number = 0;
+		protected var _y:Number = 0;
+		protected var _object:Object;
 	}
 }


### PR DESCRIPTION
This commit updates the Motion tween type to have an "object" property. Any object assigned to that property will have its x and y properties automatically updated by the Tween when it moves. The object may be of any type as long as it allows assignment to "x" and "y", so instances of the Entity, Graphics and Point classes are all valid.

The change should be perfectly backwards compatible, as you can still get the values directly from the Tween's x and y properties. Providing an object is optional, and the Motion tween will still run without it. All Motion sub-classes (including user made ones) should continue to work without any changes.

See <a href="http://flashpunk.net/forums/index.php?topic=3982.0">this forum thread</a> for the inspiration for this change. Really that post was just the straw the broke the camel's back, as the obnoxiousness of Motion tweens had been bothering me for quite a while.

Further opportunities for improvement:
- The object might be added as an optional parameter in the constructor or setMotion() method.
- The CircularMotion subclass might be able to assign its _angle property to certain kinds of target objects (Images and maybe Entities with an Image set as its graphic).
