### PR TITLE
Update net/flashpunk/Mask.as

### DIFF
--- a/net/flashpunk/Mask.as
+++ b/net/flashpunk/Mask.as
@@ -66,8 +66,8 @@
 			if (!list && parent) update();
 		}
 		
-		/** @private Updates the parent's bounds for this mask. */
-		protected function update():void
+		/** @public Updates the parent's bounds for this mask. */
+		public function update():void
 		{
 			
 		}


### PR DESCRIPTION
updated base object's function to public to preserve inheritence in Mask children
(related to Issue#59)
