### PR TITLE
abstracting Stage to allow for social network or portal submissions of FlashPunk games

### DIFF
--- a/net/flashpunk/Engine.as
+++ b/net/flashpunk/Engine.as
@@ -13,6 +13,8 @@
 
 	import net.flashpunk.utils.Draw;
 	import net.flashpunk.utils.Input;
+	
+	import flash.display.DisplayObject;
 
 	/**
 	 * Main game Sprite class, added to the Flash Stage. Manages the game loop.
@@ -45,8 +47,9 @@
 		 * @param	height			The height of your game.
 		 * @param	frameRate		The game framerate, in frames per second.
 		 * @param	fixed			If a fixed-framerate should be used.
+		 * @param       tdisplayObject          A DisplayObject for use as your root
 		 */
-		public function Engine(width:uint, height:uint, frameRate:Number = 60, fixed:Boolean = false) 
+		public function Engine(width:uint, height:uint, frameRate:Number = 60, fixed:Boolean = false, tdisplayObject:DisplayObject = null) 
 		{
 			// global game properties
 			FP.width = width;
@@ -70,8 +73,21 @@
 			FP.entity = new Entity;
 			FP._time = getTimer();
 			
-			// on-stage event listener
-			addEventListener(Event.ADDED_TO_STAGE, onStage);
+			if (tdisplayObject == null) {
+		        
+		           //we have no given DisplayObject to use as 
+		           //our Stage, so we can continue on with the
+		           //original Engine startup
+			   addEventListener(Event.ADDED_TO_STAGE, onStage);
+				
+			}else {
+			   // set stage the given DisplayObject
+			   FP.stage = tdisplayObject;
+				
+			   //continue on with the Engine startup
+			   startup();
+				
+			}
 		}
 		
 		/**
@@ -153,16 +169,21 @@
 		/** @private Event handler for stage entry. */
 		private function onStage(e:Event = null):void
 		{
-			// remove event listener
+		        // remove event listener
 			removeEventListener(Event.ADDED_TO_STAGE, onStage);
-			
-			// add focus change listeners
-			stage.addEventListener(Event.ACTIVATE, onActivate);
-			stage.addEventListener(Event.DEACTIVATE, onDeactivate);
 			
 			// set stage properties
 			FP.stage = stage;
 			setStageProperties();
+			
+			startup();
+		}
+		
+		private function startup():void
+		{
+			// add focus change listeners
+			stage.addEventListener(Event.ACTIVATE, onActivate);
+			stage.addEventListener(Event.DEACTIVATE, onDeactivate);
 			
 			// enable input
 			Input.enable();
@@ -190,6 +211,7 @@
 				_last = getTimer();
 				addEventListener(Event.ENTER_FRAME, onEnterFrame);
 			}
+			
 		}
 		
 		/** @private Framerate independent game loop. */

--- a/net/flashpunk/FP.as
+++ b/net/flashpunk/FP.as
@@ -15,6 +15,8 @@
 	import net.flashpunk.debug.Console;
 	import net.flashpunk.tweens.misc.Alarm;
 	import net.flashpunk.tweens.misc.MultiVarTween;
+	
+	import flash.display.DisplayObject;
 
 	/**
 	 * Static catch-all class used to access global properties and functions.
@@ -1048,7 +1050,7 @@
 		/** @private */ public static const RAD:Number = Math.PI / -180;
 		
 		// Global Flash objects.
-		/** @private */ public static var stage:Stage;
+		/** @private */ public static var stage:DisplayObject;
 		/** @private */ public static var engine:Engine;
 		
 		// Global objects used for rendering, collision, etc.


### PR DESCRIPTION
FP and Engine both bind to Stage during initialization which can interfere with website and social network API's that need to do the same.

FP.stage is modified to DisplayObject to allow for you to pass in a given DisplayObject into the Engine constructor. I made it an optional parameter in order to preserve existing FlashPunk games and to avoid the community chasing me with pitchforks.

Note that this @CaffeineViking deserves all the praise and glory if this fix helps you out. All I've done is abstract it into a pull request for the rest of the community.

(reference: http://dev.playvue.com/2013/07/using-root-instead-of-stage-in-flashpunk-haxepunk/)
