### PR TITLE
Sfx gapless looping

### DIFF
--- a/net/flashpunk/Sfx.as
+++ b/net/flashpunk/Sfx.as
@@ -28,7 +28,7 @@
 			if (source is Class)
 			{
 				_sound = _sounds[source];
-				if (!_sound) _sound = _sounds[source] = new source;
+				if (!_sound) _sound = _sounds[source] = new source as Sound;
 			}
 			else if (source is Sound) _sound = source;
 			else throw new Error("Sfx source needs to be of type Class or Sound");
@@ -40,7 +40,7 @@
 		 * @param	vol		Volume factor, a value from 0 to 1.
 		 * @param	pan		Panning factor, a value from -1 to 1.
 		 */
-		public function play(vol:Number = 1, pan:Number = 0):void
+		public function play(vol:Number = 1, pan:Number = 0, loops:int = 0):void
 		{
 			if (_channel) stop();
 			_pan = FP.clamp(pan, -1, 1);
@@ -49,7 +49,7 @@
 			_filteredVol = Math.max(0, _vol * getVolume(_type));
 			_transform.pan = _filteredPan;
 			_transform.volume = _filteredVol;
-			_channel = _sound.play(0, 0, _transform);
+			_channel = _sound.play(0, loops, _transform);
 			if (_channel)
 			{
 				addPlaying();
@@ -66,7 +66,7 @@
 		 */
 		public function loop(vol:Number = 1, pan:Number = 0):void
 		{
-			play(vol, pan);
+			play(vol, pan, int.MAX_VALUE);
 			_looping = true;
 		}
 		
@@ -90,7 +90,8 @@
 		 */
 		public function resume():void
 		{
-			_channel = _sound.play(_position, 0, _transform);
+			if (_looping) _channel = _sound.play(_position, int.MAX_VALUE, _transform);
+			else _channel = _sound.play(_position, 0, _transform);
 			if (_channel)
 			{
 				addPlaying();
@@ -102,9 +103,11 @@
 		/** @private Event handler for sound completion. */
 		private function onComplete(e:Event = null):void
 		{
-			if (_looping) loop(_vol, _pan);
-			else stop();
-			_position = 0;
+			if (!_looping) 
+			{
+				stop();
+				_position = 0;
+			}
 			if (complete != null) complete();
 		}
 		
@@ -256,3 +259,4 @@
 		/** @private */ private static var _typeTransforms:Dictionary = new Dictionary;
 	}
 }
+

--- a/net/flashpunk/Sfx.as
+++ b/net/flashpunk/Sfx.as
@@ -28,7 +28,7 @@
 			if (source is Class)
 			{
 				_sound = _sounds[source];
-				if (!_sound) _sound = _sounds[source] = new source as Sound;
+				if (!_sound) _sound = _sounds[source] = new source;
 			}
 			else if (source is Sound) _sound = source;
 			else throw new Error("Sfx source needs to be of type Class or Sound");
@@ -39,6 +39,7 @@
 		 * Plays the sound once.
 		 * @param	vol		Volume factor, a value from 0 to 1.
 		 * @param	pan		Panning factor, a value from -1 to 1.
+		 * @param	loops		Amount of times to repeat the song.
 		 */
 		public function play(vol:Number = 1, pan:Number = 0, loops:int = 0):void
 		{
@@ -259,4 +260,3 @@
 		/** @private */ private static var _typeTransforms:Dictionary = new Dictionary;
 	}
 }
-


### PR DESCRIPTION
A small (and slightly hackish) fix to the small gaps that happened when looping some songs. Note that this does not solve the start/end gaps inherent to MP3 compression. As a side effect it adds the option to play a piece of music N times via play().

Edit: Nevermind, while this fixes gaps when looping, it adds problems with pausing the music.
