### PR TITLE
Tilemap.loadString - Ingore negative values

### DIFF
--- a/net/flashpunk/graphics/Tilemap.as
+++ b/net/flashpunk/graphics/Tilemap.as
@@ -300,7 +300,7 @@
 				for (x = 0; x < cols; x ++)
 				{
 					if (col[x] == '') continue;
-					setTile(x, y, uint(col[x]));
+					if (col[x] >= 0) setTile(x, y, uint(col[x]));
 				}
 			}
 			

--- a/net/flashpunk/graphics/Tilemap.as
+++ b/net/flashpunk/graphics/Tilemap.as
@@ -299,8 +299,8 @@
 				cols = col.length;
 				for (x = 0; x < cols; x ++)
 				{
-					if (col[x] == '') continue;
-					if (col[x] >= 0) setTile(x, y, uint(col[x]));
+					if (col[x] == '' || int(col[x]) < 0) continue;
+					setTile(x, y, uint(col[x]));
 				}
 			}
 			


### PR DESCRIPTION
Tilemap.loadString ln 303
"Ogmo Editor" outputs -1 in it's string if a tile is not present, the tilemap class handles this poorly due to the uint conversion. Proposed change handles negative values by ignoring them and not adding a tile.
