### PR TITLE
added setRotation() to particle system

### DIFF
--- a/net/flashpunk/graphics/Emitter.as
+++ b/net/flashpunk/graphics/Emitter.as
@@ -191,12 +191,13 @@
 		 * @param	spanAngle		Total amount of degrees to rotate.
 		 * @param	startAngleRange	Random amount to add to the particle's starting angle.
 		 * @param	spanAngleRange	Random amount to add to the particle's span angle.
+		 * @param	smooth			Whether to smooth the resulting rotated particle.
 		 * @param	ease			Optional easer function.
 		 * @return	This ParticleType object.
 		 */
-		public function setRotation(name:String, startAngle:Number, spanAngle:Number, startAngleRange:Number = 0, spanAngleRange:Number = 0, ease:Function = null):ParticleType
+		public function setRotation(name:String, startAngle:Number, spanAngle:Number, startAngleRange:Number = 0, spanAngleRange:Number = 0, smooth:Boolean = false, ease:Function = null):ParticleType
 		{
-			return _types[name].setRotation(startAngle, spanAngle, startAngleRange, spanAngleRange, ease);
+			return _types[name].setRotation(startAngle, spanAngle, startAngleRange, spanAngleRange, smooth, ease);
 		}
 		
 		/**

--- a/net/flashpunk/graphics/Emitter.as
+++ b/net/flashpunk/graphics/Emitter.as
@@ -2,6 +2,7 @@
 {
 	import flash.display.BitmapData;
 	import flash.geom.ColorTransform;
+	import flash.geom.Matrix;
 	import flash.geom.Point;
 	import flash.geom.Rectangle;
 
@@ -133,7 +134,18 @@
 					type._buffer.colorTransform(type._bufferRect, _tint);
 					
 					// draw particle
-					target.copyPixels(type._buffer, type._bufferRect, _p, null, null, true);
+					if (type._isRotating) {
+						var _rotationT:Number = (type._rotationEase == null) ? t : type._rotationEase(t);
+						_matrix.identity();
+						_matrix.tx = -type.originX;
+						_matrix.ty = -type.originY;
+						_matrix.rotate(p._rotation + _rotationT * p._totalRotation);
+						_matrix.tx += type.originX + _p.x;
+						_matrix.ty += type.originY + _p.y;
+						target.draw(type._buffer, _matrix, null, null, null, type._smooth);
+					} else {
+						target.copyPixels(type._buffer, type._bufferRect, _p, null, null, true);
+					}
 				}
 				else target.copyPixels(type._source, rect, _p, null, null, true);
 				
@@ -170,6 +182,21 @@
 		public function setMotion(name:String, angle:Number, distance:Number, duration:Number, angleRange:Number = 0, distanceRange:Number = 0, durationRange:Number = 0, ease:Function = null):ParticleType
 		{
 			return (_types[name] as ParticleType).setMotion(angle, distance, duration, angleRange, distanceRange, durationRange, ease);
+		}
+		
+		/**
+		 * Defines the rotation range for a particle type.
+		 * @param	name			The particle type.
+		 * @param	startAngle		Starting angle.
+		 * @param	spanAngle		Total amount of degrees to rotate.
+		 * @param	startAngleRange	Random amount to add to the particle's starting angle.
+		 * @param	spanAngleRange	Random amount to add to the particle's span angle.
+		 * @param	ease			Optional easer function.
+		 * @return	This ParticleType object.
+		 */
+		public function setRotation(name:String, startAngle:Number, spanAngle:Number, startAngleRange:Number = 0, spanAngleRange:Number = 0, ease:Function = null):ParticleType
+		{
+			return _types[name].setRotation(startAngle, spanAngle, startAngleRange, spanAngleRange, ease);
 		}
 		
 		/**
@@ -241,6 +268,8 @@
 			p._moveY = Math.sin(a) * d;
 			p._x = x;
 			p._y = y;
+			p._rotation = type._startAngle + type._startAngleRange * FP.random;
+			p._totalRotation = type._spanAngle + type._spanAngleRange * FP.random;
 			p._gravity = type._gravity + type._gravityRange * FP.random;
 			_particleCount ++;
 			return (_particle = p);
@@ -268,5 +297,6 @@
 		// Drawing information.
 		/** @private */ private var _p:Point = new Point;
 		/** @private */ private var _tint:ColorTransform = new ColorTransform;
+		/** @private */ private var _matrix:Matrix = new Matrix;
 	}
 }

--- a/net/flashpunk/graphics/Particle.as
+++ b/net/flashpunk/graphics/Particle.as
@@ -24,6 +24,10 @@
 		/** @private */ internal var _moveX:Number;
 		/** @private */ internal var _moveY:Number;
 		
+		// Rotation information.
+		/** @private */ internal var _rotation:Number;
+		/** @private */ internal var _totalRotation:Number;
+
 		// Gravity information.
 		/** @private */ internal var _gravity:Number;
 		

--- a/net/flashpunk/graphics/ParticleType.as
+++ b/net/flashpunk/graphics/ParticleType.as
@@ -12,6 +12,19 @@
 	public class ParticleType 
 	{
 		/**
+		 * X origin of the frame, determines transformation point.
+		 * Defaults to top-left corner.
+		 */
+		public var originX:Number = 0;
+
+		/**
+		 * Y origin of the frame, determines transformation point.
+		 * Defaults to top-left corner.
+		 */
+		public var originY:Number = 0;
+		
+		
+		/**
 		 * Constructor.
 		 * @param	name			Name of the particle type.
 		 * @param	frames			Array of frame indices to animate through.
@@ -71,6 +84,30 @@
 			return this;
 		}
 		
+		/**
+		 * Defines the rotation range for this particle type.
+		 * @param	name			The particle type.
+		 * @param	startAngle		Starting angle.
+		 * @param	spanAngle		Total amount of degrees to rotate.
+		 * @param	startAngleRange	Random amount to add to the particle's starting angle.
+		 * @param	spanAngleRange	Random amount to add to the particle's span angle.
+		 * @param	smooth			Whether to smooth the resulting rotated particle.
+		 * @param	ease			Optional easer function.
+		 * @return	This ParticleType object.
+		 */
+		public function setRotation(startAngle:Number, spanAngle:Number, startAngleRange:Number = 0, spanAngleRange:Number = 0, smooth:Boolean = false, ease:Function = null):ParticleType
+		{
+			_isRotating = true;
+			_startAngle = startAngle * FP.RAD;
+			_spanAngle = spanAngle * FP.RAD;
+			_startAngleRange = startAngleRange * FP.RAD;
+			_spanAngleRange = spanAngleRange * FP.RAD;
+			_smooth = smooth;
+			_rotationEase = ease;
+			createBuffer();
+			return this;
+		}
+
 		/**
 		 * Sets the gravity range of this particle type.
 		 * @param	gravity			Gravity amount to affect to the particle y velocity.
@@ -149,6 +186,15 @@
 		/** @private */ internal var _durationRange:Number;
 		/** @private */ internal var _ease:Function;
 		
+		// Rotation information.
+		/** @private */ internal var _isRotating:Boolean = false;
+		/** @private */ internal var _startAngle:Number = 0;
+		/** @private */ internal var _startAngleRange:Number = 0;
+		/** @private */ internal var _spanAngle:Number = 0;
+		/** @private */ internal var _spanAngleRange:Number = 0;
+		/** @private */ internal var _smooth:Boolean;
+		/** @private */ internal var _rotationEase:Function;
+
 		// Gravity information.
 		/** @private */ internal var _gravity:Number = 0;
 		/** @private */ internal var _gravityRange:Number = 0;


### PR DESCRIPTION
Here's a simple test using it: [code](https://dl.dropboxusercontent.com/u/32864004/dev/FPDemo/setRotationTest.zip) | [swf](https://dl.dropboxusercontent.com/u/32864004/dev/FPDemo/setRotationTest.swf)

Internal logic is separated, so if the user doesn't uses `setRotation()`, the matrix/draw step will be discarded and `copyPixels()` will be used instead.

Willingly this could be expanded to also include scaling.
