### PR TITLE
blurry-text-fix: force TextLineMetrics recalc in Text.updateTextBuffer()

### DIFF
--- a/net/flashpunk/graphics/Text.as
+++ b/net/flashpunk/graphics/Text.as
@@ -305,6 +305,9 @@
 			
 			var i:int;
 			
+			// reassign text to force a recalc of TextLineMetrics and so be sure they report correct values
+			_field.htmlText = _field.htmlText;
+			
 			var tlm: TextLineMetrics;
 			var remainder: Number;
 			var tlm_y:Number = 2;


### PR DESCRIPTION
Addressed blurry text in some edge cases, as discussed [here](http://developers.useflashpunk.net/t/questions-about-text/531).
