### PR TITLE
Fixing regression introduced by _my own_ fix-blurry-text (Draknek/FlashPunk@3b3603b4)

### DIFF
--- a/net/flashpunk/graphics/Text.as
+++ b/net/flashpunk/graphics/Text.as
@@ -306,7 +306,7 @@
 			var i:int;
 			
 			// reassign text to force a recalc of TextLineMetrics and so be sure they report correct values
-			_field.htmlText = _field.htmlText;
+			_richText ? _field.htmlText = _field.htmlText : _field.text = _field.text;
 			
 			var tlm: TextLineMetrics;
 			var remainder: Number;


### PR DESCRIPTION
It caused newlines and tabs to not work properly on _simple_ Text

See related topic on the forums: http://developers.useflashpunk.net/t/escape-characters-newline-tab-in-text-object/880
