### PR TITLE
Refactor of Tween classes (calling start() is mandatory) - to address is...

### DIFF
--- a/net/flashpunk/FP.as
+++ b/net/flashpunk/FP.as
@@ -836,7 +836,7 @@
 			}
 			var tween:MultiVarTween = new MultiVarTween(complete, type);
 			tween.tween(object, values, duration, ease, delay);
-			tweener.addTween(tween);
+			tweener.addTween(tween, true);
 			return tween;
 		}
 		

--- a/net/flashpunk/Tween.as
+++ b/net/flashpunk/Tween.as
@@ -79,20 +79,26 @@
 		
 		/**
 		 * Starts the Tween, or restarts it if it's currently running.
+		 * 
+		 * @return The tween itself for chaining.
 		 */
-		public function start():void
+		public function start():Tween
 		{
 			_time = 0;
 			if (_target == 0)
 			{
 				active = false;
-				return;
 			}
-			active = true;
+			else {
+				active = true;
+			}
+			return this;
 		}
 		
 		/**
 		 * Immediately stops the Tween and removes it from its Tweener without calling the complete callback.
+		 * 
+		 * @return The tween itself for chaining.
 		 */
 		public function cancel():void
 		{

--- a/net/flashpunk/Tween.as
+++ b/net/flashpunk/Tween.as
@@ -97,8 +97,6 @@
 		
 		/**
 		 * Immediately stops the Tween and removes it from its Tweener without calling the complete callback.
-		 * 
-		 * @return The tween itself for chaining.
 		 */
 		public function cancel():void
 		{

--- a/net/flashpunk/tweens/misc/Alarm.as
+++ b/net/flashpunk/tweens/misc/Alarm.as
@@ -19,7 +19,7 @@
 		}
 		
 		/**
-		 * Sets the alarm.
+		 * Sets the alarm and starts it.
 		 * @param	duration	Duration of the alarm.
 		 */
 		public function reset(duration:Number):void

--- a/net/flashpunk/tweens/misc/AngleTween.as
+++ b/net/flashpunk/tweens/misc/AngleTween.as
@@ -24,13 +24,15 @@
 		}
 		
 		/**
-		 * Tweens the value from one angle to another.
+		 * Tweens the value from one angle to another. You have to call start() to actually run it.
 		 * @param	fromAngle		Start angle.
 		 * @param	toAngle			End angle.
 		 * @param	duration		Duration of the tween.
 		 * @param	ease			Optional easer function.
+		 * 
+		 * @return The tween itself for chaining.
 		 */
-		public function tween(fromAngle:Number, toAngle:Number, duration:Number, ease:Function = null):void
+		public function tween(fromAngle:Number, toAngle:Number, duration:Number, ease:Function = null):AngleTween
 		{
 			_start = angle = fromAngle;
 			var d:Number = toAngle - angle,
@@ -40,7 +42,7 @@
 			else _range = FP.choose(180, -180);
 			_target = duration;
 			_ease = ease;
-			start();
+			return this;
 		}
 		
 		/** @private Updates the Tween. */

--- a/net/flashpunk/tweens/misc/ColorTween.as
+++ b/net/flashpunk/tweens/misc/ColorTween.as
@@ -29,15 +29,17 @@
 		}
 		
 		/**
-		 * Tweens the color to a new color and an alpha to a new alpha.
+		 * Tweens the color to a new color and an alpha to a new alpha. You have to call start() to actually run it.
 		 * @param	duration		Duration of the tween.
 		 * @param	fromColor		Start color.
 		 * @param	toColor			End color.
 		 * @param	fromAlpha		Start alpha
 		 * @param	toAlpha			End alpha.
 		 * @param	ease			Optional easer function.
+		 * 
+		 * @return The tween itself for chaining.
 		 */
-		public function tween(duration:Number, fromColor:uint, toColor:uint, fromAlpha:Number = 1, toAlpha:Number = 1, ease:Function = null):void
+		public function tween(duration:Number, fromColor:uint, toColor:uint, fromAlpha:Number = 1, toAlpha:Number = 1, ease:Function = null):ColorTween
 		{
 			fromColor &= 0xFFFFFF;
 			toColor &= 0xFFFFFF;
@@ -55,7 +57,7 @@
 			_rangeA = toAlpha - alpha;
 			_target = duration;
 			_ease = ease;
-			start();
+			return this;
 		}
 		
 		/** @private Updates the Tween. */

--- a/net/flashpunk/tweens/misc/MultiVarTween.as
+++ b/net/flashpunk/tweens/misc/MultiVarTween.as
@@ -18,13 +18,15 @@ package net.flashpunk.tweens.misc
 		}
 		
 		/**
-		 * Tweens multiple numeric public properties.
+		 * Tweens multiple numeric public properties. You have to call start() to actually run it.
 		 * @param	object		The object containing the properties.
 		 * @param	values		An object containing key/value pairs of properties and target values.
 		 * @param	duration	Duration of the tween.
 		 * @param	ease		Optional easer function.
+		 * 
+		 * @return The tween itself for chaining.
 		 */
-		public function tween(object:Object, values:Object, duration:Number, ease:Function = null, delay:Number = 0):void
+		public function tween(object:Object, values:Object, duration:Number, ease:Function = null, delay:Number = 0):MultiVarTween
 		{
 			_object = object;
 			_vars.length = 0;
@@ -42,7 +44,7 @@ package net.flashpunk.tweens.misc
 				_start.push(a);
 				_range.push(values[p] - a);
 			}
-			start();
+			return this;
 		}
 		
 		/** @private Updates the Tween. */

--- a/net/flashpunk/tweens/misc/NumTween.as
+++ b/net/flashpunk/tweens/misc/NumTween.as
@@ -23,19 +23,21 @@
 		}
 		
 		/**
-		 * Tweens the value from one value to another.
+		 * Tweens the value from one value to another. You have to call start() to actually run it.
 		 * @param	fromValue		Start value.
 		 * @param	toValue			End value.
 		 * @param	duration		Duration of the tween.
 		 * @param	ease			Optional easer function.
+		 * 
+		 * @return The tween itself for chaining.
 		 */
-		public function tween(fromValue:Number, toValue:Number, duration:Number, ease:Function = null):void
+		public function tween(fromValue:Number, toValue:Number, duration:Number, ease:Function = null):NumTween
 		{
 			_start = value = fromValue;
 			_range = toValue - value;
 			_target = duration;
 			_ease = ease;
-			start();
+			return this;
 		}
 		
 		/** @private Updates the Tween. */

--- a/net/flashpunk/tweens/misc/VarTween.as
+++ b/net/flashpunk/tweens/misc/VarTween.as
@@ -18,14 +18,16 @@
 		}
 		
 		/**
-		 * Tweens a numeric public property.
+		 * Tweens a numeric public property. You have to call start() to actually run it.
 		 * @param	object		The object containing the property.
 		 * @param	property	The name of the property (eg. "x").
 		 * @param	to			Value to tween to.
 		 * @param	duration	Duration of the tween.
 		 * @param	ease		Optional easer function.
+		 * 
+		 * @return The tween itself for chaining.
 		 */
-		public function tween(object:Object, property:String, to:Number, duration:Number, ease:Function = null):void
+		public function tween(object:Object, property:String, to:Number, duration:Number, ease:Function = null):VarTween
 		{
 			_object = object;
 			_property = property;
@@ -37,7 +39,7 @@
 			_range = to - _start;
 			_target = duration;
 			_ease = ease;
-			start();
+			return this;
 		}
 		
 		/** @private Updates the Tween. */

--- a/net/flashpunk/tweens/motion/CircularMotion.as
+++ b/net/flashpunk/tweens/motion/CircularMotion.as
@@ -18,7 +18,7 @@
 		}
 		
 		/**
-		 * Starts moving along a circle.
+		 * Starts moving along a circle. You have to call start() to actually run it.
 		 * @param	centerX		X position of the circle's center.
 		 * @param	centerY		Y position of the circle's center.
 		 * @param	radius		Radius of the circle.
@@ -26,8 +26,10 @@
 		 * @param	clockwise	If the motion is clockwise.
 		 * @param	duration	Duration of the movement.
 		 * @param	ease		Optional easer function.
+		 * 
+		 * @return The tween itself for chaining.
 		 */
-		public function setMotion(centerX:Number, centerY:Number, radius:Number, angle:Number, clockwise:Boolean, duration:Number, ease:Function = null):void
+		public function setMotion(centerX:Number, centerY:Number, radius:Number, angle:Number, clockwise:Boolean, duration:Number, ease:Function = null):CircularMotion
 		{
 			_centerX = centerX;
 			_centerY = centerY;
@@ -36,11 +38,11 @@
 			_angleFinish = _CIRC * (clockwise ? 1 : -1);
 			_target = duration;
 			_ease = ease;
-			start();
+			return this;
 		}
 		
 		/**
-		 * Starts moving along a circle at the speed.
+		 * Starts moving along a circle at the speed. You have to call start() to actually run it.
 		 * @param	centerX		X position of the circle's center.
 		 * @param	centerY		Y position of the circle's center.
 		 * @param	radius		Radius of the circle.
@@ -48,8 +50,10 @@
 		 * @param	clockwise	If the motion is clockwise.
 		 * @param	speed		Speed of the movement.
 		 * @param	ease		Optional easer function.
+		 * 
+		 * @return The tween itself for chaining.
 		 */
-		public function setMotionSpeed(centerX:Number, centerY:Number, radius:Number, angle:Number, clockwise:Boolean, speed:Number, ease:Function = null):void
+		public function setMotionSpeed(centerX:Number, centerY:Number, radius:Number, angle:Number, clockwise:Boolean, speed:Number, ease:Function = null):CircularMotion
 		{
 			_centerX = centerX;
 			_centerY = centerY;
@@ -58,7 +62,7 @@
 			_angleFinish = _CIRC * (clockwise ? 1 : -1);
 			_target = (_radius * _CIRC) / speed;
 			_ease = ease;
-			start();
+			return this;
 		}
 		
 		/** @private Updates the Tween. */

--- a/net/flashpunk/tweens/motion/CubicMotion.as
+++ b/net/flashpunk/tweens/motion/CubicMotion.as
@@ -16,7 +16,7 @@
 		}
 		
 		/**
-		 * Starts moving along the curve.
+		 * Starts moving along the curve. You have to call start() to actually run it.
 		 * @param	fromX		X start.
 		 * @param	fromY		Y start.
 		 * @param	aX			First control x.
@@ -27,8 +27,10 @@
 		 * @param	toY			Y finish.
 		 * @param	duration	Duration of the movement.
 		 * @param	ease		Optional easer function.
+		 * 
+		 * @return The tween itself for chaining.
 		 */
-		public function setMotion(fromX:Number, fromY:Number, aX:Number, aY:Number, bX:Number, bY:Number, toX:Number, toY:Number, duration:Number, ease:Function = null):void
+		public function setMotion(fromX:Number, fromY:Number, aX:Number, aY:Number, bX:Number, bY:Number, toX:Number, toY:Number, duration:Number, ease:Function = null):CubicMotion
 		{
 			x = _fromX = fromX;
 			y = _fromY = fromY;
@@ -40,7 +42,7 @@
 			_toY = toY;
 			_target = duration;
 			_ease = ease;
-			start();
+			return this;
 		}
 		
 		/** @private Updates the Tween. */

--- a/net/flashpunk/tweens/motion/LinearMotion.as
+++ b/net/flashpunk/tweens/motion/LinearMotion.as
@@ -16,15 +16,17 @@
 		}
 		
 		/**
-		 * Starts moving along a line.
+		 * Starts moving along a line. You have to call start() to actually run it.
 		 * @param	fromX		X start.
 		 * @param	fromY		Y start.
 		 * @param	toX			X finish.
 		 * @param	toY			Y finish.
 		 * @param	duration	Duration of the movement.
 		 * @param	ease		Optional easer function.
+		 * 
+		 * @return The tween itself for chaining.
 		 */
-		public function setMotion(fromX:Number, fromY:Number, toX:Number, toY:Number, duration:Number, ease:Function = null):void
+		public function setMotion(fromX:Number, fromY:Number, toX:Number, toY:Number, duration:Number, ease:Function = null):LinearMotion
 		{
 			_distance = -1;
 			x = _fromX = fromX;
@@ -33,19 +35,21 @@
 			_moveY = toY - fromY;
 			_target = duration;
 			_ease = ease;
-			start();
+			return this;
 		}
 		
 		/**
-		 * Starts moving along a line at the speed.
+		 * Starts moving along a line at the speed. You have to call start() to actually run it.
 		 * @param	fromX		X start.
 		 * @param	fromY		Y start.
 		 * @param	toX			X finish.
 		 * @param	toY			Y finish.
 		 * @param	speed		Speed of the movement.
 		 * @param	ease		Optional easer function.
+		 * 
+		 * @return The tween itself for chaining.
 		 */
-		public function setMotionSpeed(fromX:Number, fromY:Number, toX:Number, toY:Number, speed:Number, ease:Function = null):void
+		public function setMotionSpeed(fromX:Number, fromY:Number, toX:Number, toY:Number, speed:Number, ease:Function = null):LinearMotion
 		{
 			_distance = -1;
 			x = _fromX = fromX;
@@ -54,7 +58,7 @@
 			_moveY = toY - fromY;
 			_target = distance / speed;
 			_ease = ease;
-			start();
+			return this;
 		}
 		
 		/** @private Updates the Tween. */

--- a/net/flashpunk/tweens/motion/LinearPath.as
+++ b/net/flashpunk/tweens/motion/LinearPath.as
@@ -19,31 +19,35 @@
 		}
 		
 		/**
-		 * Starts moving along the path.
+		 * Starts moving along the path. You have to call start() to actually run it.
 		 * @param	duration		Duration of the movement.
 		 * @param	ease			Optional easer function.
+		 * 
+		 * @return The tween itself for chaining.
 		 */
-		public function setMotion(duration:Number, ease:Function = null):void
+		public function setMotion(duration:Number, ease:Function = null):LinearPath
 		{
 			updatePath();
 			_target = duration;
 			_speed = _distance / duration;
 			_ease = ease;
-			start();
+			return this;
 		}
 		
 		/**
-		 * Starts moving along the path at the speed.
+		 * Starts moving along the path at the speed. You have to call start() to actually run it.
 		 * @param	speed		Speed of the movement.
 		 * @param	ease		Optional easer function.
+		 * 
+		 * @return The tween itself for chaining.
 		 */
-		public function setMotionSpeed(speed:Number, ease:Function = null):void
+		public function setMotionSpeed(speed:Number, ease:Function = null):LinearPath
 		{
 			updatePath();
 			_target = _distance / speed;
 			_speed = speed;
 			_ease = ease;
-			start();
+			return this;
 		}
 		
 		/**

--- a/net/flashpunk/tweens/motion/QuadMotion.as
+++ b/net/flashpunk/tweens/motion/QuadMotion.as
@@ -20,7 +20,7 @@
 		}
 		
 		/**
-		 * Starts moving along the curve.
+		 * Starts moving along the curve. You have to call start() to actually run it.
 		 * @param	fromX		X start.
 		 * @param	fromY		Y start.
 		 * @param	controlX	X control, used to determine the curve.
@@ -29,8 +29,10 @@
 		 * @param	toY			Y finish.
 		 * @param	duration	Duration of the movement.
 		 * @param	ease		Optional easer function.
+		 * 
+		 * @return The tween itself for chaining.
 		 */
-		public function setMotion(fromX:Number, fromY:Number, controlX:Number, controlY:Number, toX:Number, toY:Number, duration:Number, ease:Function = null):void
+		public function setMotion(fromX:Number, fromY:Number, controlX:Number, controlY:Number, toX:Number, toY:Number, duration:Number, ease:Function = null):QuadMotion
 		{
 			_distance = -1;
 			x = _fromX = fromX;
@@ -41,11 +43,11 @@
 			_toY = toY;
 			_target = duration;
 			_ease = ease;
-			start();
+			return this;
 		}
 		
 		/**
-		 * Starts moving along the curve at the speed.
+		 * Starts moving along the curve at the speed. You have to call start() to actually run it.
 		 * @param	fromX		X start.
 		 * @param	fromY		Y start.
 		 * @param	controlX	X control, used to determine the curve.
@@ -54,8 +56,10 @@
 		 * @param	toY			Y finish.
 		 * @param	speed		Speed of the movement.
 		 * @param	ease		Optional easer function.
+		 * 
+		 * @return The tween itself for chaining.
 		 */
-		public function setMotionSpeed(fromX:Number, fromY:Number, controlX:Number, controlY:Number, toX:Number, toY:Number, speed:Number, ease:Function = null):void
+		public function setMotionSpeed(fromX:Number, fromY:Number, controlX:Number, controlY:Number, toX:Number, toY:Number, speed:Number, ease:Function = null):QuadMotion
 		{
 			_distance = -1;
 			x = _fromX = fromX;
@@ -66,7 +70,7 @@
 			_toY = toY;
 			_target = distance / speed;
 			_ease = ease;
-			start();
+			return this;
 		}
 		
 		/** @private Updates the Tween. */

--- a/net/flashpunk/tweens/motion/QuadPath.as
+++ b/net/flashpunk/tweens/motion/QuadPath.as
@@ -21,31 +21,35 @@
 		}
 		
 		/**
-		 * Starts moving along the path.
+		 * Starts moving along the path. You have to call start() to actually run it.
 		 * @param	duration	Duration of the movement.
 		 * @param	ease		Optional easer function.
+		 * 
+		 * @return The tween itself for chaining.
 		 */
-		public function setMotion(duration:Number, ease:Function = null):void
+		public function setMotion(duration:Number, ease:Function = null):QuadPath
 		{
 			updatePath();
 			_target = duration;
 			_speed = _distance / duration;
 			_ease = ease;
-			start();
+			return this;
 		}
 		
 		/**
-		 * Starts moving along the path at the speed.
+		 * Starts moving along the path at the speed. You have to call start() to actually run it.
 		 * @param	speed		Speed of the movement.
 		 * @param	ease		Optional easer function.
+		 * 
+		 * @return The tween itself for chaining.
 		 */
-		public function setMotionSpeed(speed:Number, ease:Function = null):void
+		public function setMotionSpeed(speed:Number, ease:Function = null):QuadPath
 		{
 			updatePath();
 			_target = _distance / speed;
 			_speed = speed;
 			_ease = ease;
-			start();
+			return this;
 		}
 		
 		/**

--- a/net/flashpunk/tweens/sound/Fader.as
+++ b/net/flashpunk/tweens/sound/Fader.as
@@ -19,19 +19,21 @@
 		}
 		
 		/**
-		 * Fades FP.volume to the target volume.
+		 * Fades FP.volume to the target volume. You have to call start() to actually run it.
 		 * @param	volume		The volume to fade to.
 		 * @param	duration	Duration of the fade.
 		 * @param	ease		Optional easer function.
+		 * 
+		 * @return The tween itself for chaining.
 		 */
-		public function fadeTo(volume:Number, duration:Number, ease:Function = null):void
+		public function fadeTo(volume:Number, duration:Number, ease:Function = null):Fader
 		{
 			if (volume < 0) volume = 0;
 			_start = FP.volume;
 			_range = volume - _start;
 			_target = duration;
 			_ease = ease;
-			start();
+			return this;
 		}
 		
 		/** @private Updates the Tween. */

--- a/net/flashpunk/tweens/sound/SfxFader.as
+++ b/net/flashpunk/tweens/sound/SfxFader.as
@@ -22,30 +22,34 @@
 		}
 		
 		/**
-		 * Fades the Sfx to the target volume.
+		 * Fades the Sfx to the target volume. You have to call start() to actually run it.
 		 * @param	volume		The volume to fade to.
 		 * @param	duration	Duration of the fade.
 		 * @param	ease		Optional easer function.
+		 * 
+		 * @return The tween itself for chaining.
 		 */
-		public function fadeTo(volume:Number, duration:Number, ease:Function = null):void
+		public function fadeTo(volume:Number, duration:Number, ease:Function = null):SfxFader
 		{
 			if (volume < 0) volume = 0;
 			_start = _sfx.volume;
 			_range = volume - _start;
 			_target = duration;
 			_ease = ease;
-			start();
+			return this;
 		}
 		
 		/**
-		 * Fades out the Sfx, while also playing and fading in a replacement Sfx.
+		 * Fades out the Sfx, while also playing and fading in a replacement Sfx. You have to call start() to actually run it.
 		 * @param	play		The Sfx to play and fade in.
 		 * @param	loop		If the new Sfx should loop.
 		 * @param	duration	Duration of the crossfade.
 		 * @param	volume		The volume to fade in the new Sfx to.
 		 * @param	ease		Optional easer function.
+		 * 
+		 * @return The tween itself for chaining.
 		 */
-		public function crossFade(play:Sfx, loop:Boolean, duration:Number, volume:Number = 1, ease:Function = null):void
+		public function crossFade(play:Sfx, loop:Boolean, duration:Number, volume:Number = 1, ease:Function = null):SfxFader
 		{
 			_crossSfx = play;
 			_crossRange = volume;
@@ -55,7 +59,7 @@
 			_ease = ease;
 			if (loop) _crossSfx.loop(0);
 			else _crossSfx.play(0);
-			start();
+			return this;
 		}
 		
 		/** @private Updates the Tween. */


### PR DESCRIPTION
...sue #128:
- all tween packages/classes are affected by these changes (misc, motion, sound, FP)
- the call to start() has been removed from tween()
- tween() returns the (specific) tween itself for chaining
- Tween.start() also returns the tween itself for chaining (you'd probably have to cast it to the proper tween)

Why? `addTween(_someTween_, true/false)` should now behave correctly.

I've tested it... maybe not thoroughly but... Any thoughts/comments about this?
