### PR TITLE
Fix Hitboxes in Masklists not showing in renderDebug and corrected value...

### DIFF
--- a/net/flashpunk/masks/Hitbox.as
+++ b/net/flashpunk/masks/Hitbox.as
@@ -1,5 +1,6 @@
 ﻿package net.flashpunk.masks 
 {
+	import flash.display.Graphics;
 	import net.flashpunk.*;
 	
 	/**
@@ -108,6 +109,17 @@
 				parent.width = _width;
 				parent.height = _height;
 			}
+		}
+		
+		public override function renderDebug(g:Graphics):void
+		{
+			// draw only if we're part of a Masklist
+			if (!list) return;
+			
+			var sx:Number = FP.screen.scaleX * FP.screen.scale;
+			var sy:Number = FP.screen.scaleY * FP.screen.scale;
+			
+			g.drawRect((parent.x - FP.camera.x + x) * sx, (parent.y - FP.camera.y + y) * sy, width * sx, height * sy);
 		}
 		
 		// Hitbox information.

--- a/net/flashpunk/masks/Masklist.as
+++ b/net/flashpunk/masks/Masklist.as
@@ -135,6 +135,8 @@
 		{
 			// find bounds of the contained masks
 			var t:int, l:int, r:int, b:int, h:Hitbox, i:int = _count;
+			l = t = int.MAX_VALUE;
+			r = b = int.MIN_VALUE;
 			while (i --)
 			{
 				if ((h = _masks[i] as Hitbox))


### PR DESCRIPTION
...s in Masklists.update()

![](https://dl.dropboxusercontent.com/u/32864004/dev/FPDemo/tappy-plane-before-after-fix.png)
before vs after fix

Now the calc of the Entity Mask bounds in Masklist should be fixed, and Hitbox has it's own renderDebug() which is executed only if it's part of a Masklist - this avoids to draw the same rect twice.
