### PR TITLE
Fix for Text's setStyle() description/example in generated docs

### DIFF
--- a/net/flashpunk/graphics/Text.as
+++ b/net/flashpunk/graphics/Text.as
@@ -137,7 +137,7 @@
 		 * Usage:
 		   text.setStyle("red", {color: 0xFF0000});
 		   text.setStyle("big", {size: text.size*2});
-		   text.richText = "<big>Hello</big> <red>world</red>";
+		   text.richText = "&lt;big&gt;Hello&lt;/big&gt; &lt;red&gt;world&lt;/red&gt;";
 		 */
 		public function setStyle(tagName:String, params:*):void
 		{


### PR DESCRIPTION
The `setStyle()` method in `Text.as` does not appear correctly in the documentation, because it is using an HTML-like syntax that `asdoc` treats as raw HTML. Therefore the example does not actually show the proper usage for the method.

I changed it to use HTML entities `&lt;` and `&gt;` so it will now work properly in documentation.
