### PR TITLE
In Text, added an small feature.

### DIFF
--- a/net/flashpunk/graphics/Text.as
+++ b/net/flashpunk/graphics/Text.as
@@ -336,7 +336,7 @@
 					tlm_y += tlm.height;
 				}
 			} else {
-				_source.draw(_field);
+				_source.draw(_field, _field.transform.matrix);
 			}
 			
 			super.updateBuffer();


### PR DESCRIPTION
An small modification that allows a modified matrix always be rendered (not only if offsetRequired is true).
This allows to directly modify the _field.transform.matrix making Text rotate, scale and be partially rendered.
Edit: Found a bug created for this.
