### PR TITLE
Fix Data.clear() and add Emitter.simulate(time)

### DIFF
--- a/net/flashpunk/Engine.as
+++ b/net/flashpunk/Engine.as
@@ -63,6 +63,7 @@
 			FP.assignedFrameRate = frameRate;
 			FP.fixed = fixed;
 			FP.timeInFrames = fixed;
+			FP._interval = 1.0 / frameRate;
 			
 			// global game objects
 			FP.engine = this;

--- a/net/flashpunk/FP.as
+++ b/net/flashpunk/FP.as
@@ -211,7 +211,7 @@
 		 */
 		public static function choose(...objs):*
 		{
-			var c:* = (objs.length == 1 && (objs[0] is Array || objs[0] is Vector.<*>)) ? objs[0] : objs;
+			var c:* = (objs.length == 1 && (objs[0] is Array || isVector(objs[0]))) ? objs[0] : objs;
 			return c[rand(c.length)];
 		}
 		
@@ -905,7 +905,7 @@
 		 */
 		public static function shuffle(a:Object):void
 		{
-			if (a is Array || a is Vector.<*>)
+			if (a is Array || isVector(a))
 			{
 				var i:int = a.length, j:int, t:*;
 				while (-- i)
@@ -924,7 +924,7 @@
 		 */
 		public static function sort(object:Object, ascending:Boolean = true):void
 		{
-			if (object is Array || object is Vector.<*>)
+			if (object is Array || isVector(object))
 			{
 				// Only need to sort the array if it has more than one item.
 				if (object.length > 1)
@@ -942,7 +942,7 @@
 		 */
 		public static function sortBy(object:Object, property:String, ascending:Boolean = true):void
 		{
-			if (object is Array || object is Vector.<*>)
+			if (object is Array || isVector(object))
 			{
 				// Only need to sort the array if it has more than one item.
 				if (object.length > 1)
@@ -1024,6 +1024,11 @@
 			}
 			if (left < j) quicksortBy(a, left, j, ascending, property);
 			if (i < right) quicksortBy(a, i, right, ascending, property);
+		}
+		/** @private Determines whether an object is any of the four Vector specializations. */
+		private static function isVector(object:Object):Boolean
+		{
+			return object is Vector.<*> || object is Vector.<Number> || object is Vector.<uint> || object is Vector.<int>;
 		}
 		
 		// World information.

--- a/net/flashpunk/FP.as
+++ b/net/flashpunk/FP.as
@@ -73,6 +73,11 @@
 		public static var elapsed:Number;
 		
 		/**
+		 * The ideal interval (in fractional seconds) between frames.
+		 */
+		public static function get interval():Number { return _interval; }
+		
+		/**
 		 * Timescale applied to FP.elapsed.
 		 */
 		public static var rate:Number = 1;
@@ -1030,6 +1035,7 @@
 		
 		// Time information.
 		/** @private */ internal static var _time:uint;
+		/** @private */ internal static var _interval:Number;
 		/** @private */ public static var _updateTime:uint;
 		/** @private */ public static var _renderTime:uint;
 		/** @private */ public static var _gameTime:uint;

--- a/net/flashpunk/debug/Console.as
+++ b/net/flashpunk/debug/Console.as
@@ -76,7 +76,7 @@ package net.flashpunk.debug
 			{
 				for each (i in properties) WATCH_LIST.push(i);
 			}
-			else if (properties[0] is Array || properties[0] is Vector.<*>)
+			else if (properties[0] is Array || properties[0] is Vector.<String>)
 			{
 				for each (i in properties[0]) WATCH_LIST.push(i);
 			}

--- a/net/flashpunk/graphics/Emitter.as
+++ b/net/flashpunk/graphics/Emitter.as
@@ -51,15 +51,24 @@
 			if (!_particle) return;
 			
 			// particle info
-			var e:Number = FP.timeInFrames ? 1 : FP.elapsed,
-				p:Particle = _particle,
+			var e:Number = FP.timeInFrames ? 1 : FP.elapsed;
+			simulate(e);
+		}
+		
+		/**
+		 * Simulate the emitter running for a given amount of time.
+		 * @param	time The time to run for, in seconds or frames depending on Engine timestep mode.
+		 */
+		public function simulate(time:Number):void
+		{
+			var p:Particle = _particle,
 				n:Particle;
 			
 			// loop through the particles
 			while (p)
 			{
 				// update time scale
-				p._time += e;
+				p._time += time;
 				
 				// remove on time-out
 				if (p._time >= p._duration)

--- a/net/flashpunk/utils/Data.as
+++ b/net/flashpunk/utils/Data.as
@@ -120,11 +120,10 @@
 		}
 		
 		/**
-		 * Clears save file.
-		 * @param	filename Save file to clear.
+		 * Clears the current data.
 		 */
-		public static function clear(filename:String):void {
-			Data.load(filename);
+		public static function clear():void
+		{
 			_shared.clear();
 		}
 		


### PR DESCRIPTION
Incorporates a change to the Data API as discussed [here](https://github.com/useflashpunk/FlashPunk/pull/142#issuecomment-64084909), and adds a method to the Emitter class which allows the passage of time to be simulated for "pre-warming" particles. Demo and discussion [here](http://developers.useflashpunk.net/t/emitter-simulate-feature-discussion/1927).
