### PR TITLE
Add frontCollidePoint function to World.as

### DIFF
--- a/net/flashpunk/World.as
+++ b/net/flashpunk/World.as
@@ -995,6 +995,31 @@
 			}
 		}
 		
+		/**
+		 * Returns the Entity at front which collides with the point.
+		 * @param   x       X position
+		 * @param   y       Y position
+		 * @return The Entity at front which collides with the point, or null if not found.
+		 */
+		public function frontCollidePoint(x:Number, y:Number):Entity
+		{
+			var e:Entity,
+			i:int = 0,
+			l:int = _layerList.length;
+			do
+			{
+				e = _renderFirst[_layerList[i]];
+				while (e)
+				{
+					if(e.collidePoint(e.x, e.y, x, y)) return e;
+					e = e._renderNext
+				}
+				if(i > l) break;
+			}
+			while(++i);
+				return null;
+		}
+		
 		/** @private Adds Entity to the update list. */
 		private function addUpdate(e:Entity):void
 		{


### PR DESCRIPTION
Add the frontCollidePoint function to World.as that allows the [punk.ui project](https://github.com/RichardMarks/punk.ui) to work without modification on a per-project basis.

Code provided by the punk.ui wiki here: https://github.com/RichardMarks/punk.ui/wiki/Additional-function-on-World